### PR TITLE
Refresh wallet balance more regularly.

### DIFF
--- a/src/strategies/naive.py
+++ b/src/strategies/naive.py
@@ -96,6 +96,15 @@ async def strategy(
     except ValueError as e:
         logger.error("Failed to rebalance portfolio: %s", e)
 
+    ctx = ctx.with_state(state.poll(ctx, pools, auctions))
+
+    if not state.balance:
+        return ctx
+
+    logger.info(
+        f"Starting arbitrage round with {state.balance} {ctx.cli_args['base_denom']}"
+    )
+
     # Report route stats to user
     logger.info(
         "Finding profitable routes",

--- a/src/strategies/naive.py
+++ b/src/strategies/naive.py
@@ -63,8 +63,7 @@ class State:
             ),
         )
 
-        if balance_resp:
-            self.balance = balance_resp
+        self.balance = balance_resp
 
         return self
 


### PR DESCRIPTION
Currently, there is a bug in Osmosis trades which causes transactions to fail to execute, due to the wallet balance being lower than the execution plan specifies. The only explanation for this is that the execution plan is being created with a stale starting amount (wallet balance). One possible explanation for this behavior is rebalancing in between wallet balance fetching and route evaluation. This PR refreshes the wallet balance after rebalancing to remedy this issue.

Note: This will not fix the underlying issue - wallet funds getting stuck somewhere before the trade is executed. Further testing will be done to verify the source of this behavior.