### PR TITLE
Osmosis Integration Tests + Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Debug information is logged to the DEBUG level, including:
 * Profit levels for considered trades
 * Intermediate debug logs
 
-The log level may be set via the `LOGLEVEL` environment variable. Possible values are: `INFO`, `DEBUG`, or `ERROR`.
+The log level may be set via the `LOGLEVEL` environment variable. Possible values are: `info`, `debug`, or `error`.
 
 An example output is as follows:
 

--- a/local-interchaintest/Cargo.lock
+++ b/local-interchaintest/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared_child",
+ "sqlite",
 ]
 
 [[package]]
@@ -1966,6 +1967,34 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfe6fb16f2bee6452feeb4d12bfa404fbcd3cfc121b2950e501d1ae9cae718e"
+dependencies = [
+ "sqlite3-sys",
+]
+
+[[package]]
+name = "sqlite3-src"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "174d4a6df77c27db281fb23de1a6d968f3aaaa4807c2a1afa8056b971f947b4a"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "sqlite3-sys"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3901ada7090c3c3584dc92ec7ef1b7091868d13bfe6d7de9f0bcaffee7d0ade5"
+dependencies = [
+ "sqlite3-src",
 ]
 
 [[package]]

--- a/local-interchaintest/Cargo.toml
+++ b/local-interchaintest/Cargo.toml
@@ -15,3 +15,4 @@ itertools = "0.13.0"
 shared_child = "1.0.0"
 clap = { version = "4.5.8", features = ["derive"] }
 derive_builder = "0.20.0"
+sqlite = { version = "0.36.1" }

--- a/local-interchaintest/chains/neutron_osmosis_gaia.json
+++ b/local-interchaintest/chains/neutron_osmosis_gaia.json
@@ -167,7 +167,7 @@
       "binary": "osmosisd",
       "bech32_prefix": "osmo",
       "docker_image": {
-        "version": "v25.0.4",
+        "version": "v26.0.2",
         "repository": "ghcr.io/strangelove-ventures/heighliner/osmosis"
       },
       "gas_prices": "0.0025%DENOM%",

--- a/local-interchaintest/src/main.rs
+++ b/local-interchaintest/src/main.rs
@@ -183,6 +183,56 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
                 .with_test(Box::new(tests::test_unprofitable_arb) as TestFn)
                 .build()?,
         )?
+        // Test case unprofitable osmo arb:
+        //
+        // - Astro: untrn-bruhtoken @ 1.5 bruhtoken/untrn
+        // - Osmo: bruhtoken-uosmo @ 0.001 uosmo/bruhtoken
+        // - Astro: uosmo-untrn @ 1 untrn/uosmo
+        .run(
+            TestBuilder::default()
+                .with_name("Osmosis Arb")
+                .with_description("The arbitrage bot not execute an unprofitable arb on Osmosis")
+                .with_denom(untrn_osmo.clone(), 100000000000)
+                .with_denom(uosmo.clone(), 100000000000)
+                .with_denom(bruhtoken.clone(), 100000000000)
+                .with_denom(untrn.clone(), 100000000000)
+                .with_denom(bruhtoken_osmo.clone(), 100000000000)
+                .with_pool(
+                    untrn.clone(),
+                    uosmo_ntrn.clone(),
+                    Pool::Astroport(
+                        AstroportPoolBuilder::default()
+                            .with_balance_asset_a(10000000u128)
+                            .with_balance_asset_b(15000000u128)
+                            .build()?,
+                    ),
+                )
+                .with_pool(
+                    uosmo.clone(),
+                    bruhtoken_osmo.clone(),
+                    Pool::Osmosis(
+                        OsmosisPoolBuilder::default()
+                            .with_funds(bruhtoken_osmo.clone(), 100000000u128)
+                            .with_funds(uosmo.clone(), 100000u128)
+                            .with_weight(bruhtoken_osmo.clone(), 100u128)
+                            .with_weight(uosmo.clone(), 1u128)
+                            .build(),
+                    ),
+                )
+                .with_pool(
+                    untrn.clone(),
+                    bruhtoken.clone(),
+                    Pool::Auction(
+                        AuctionPoolBuilder::default()
+                            .with_balance_offer_asset(10000000u128)
+                            .with_price(Decimal::percent(10))
+                            .build()?,
+                    ),
+                )
+                .with_arbbot()
+                .with_test(Box::new(tests::test_unprofitable_osmo_arb) as TestFn)
+                .build()?,
+        )?
         // Test case (astro -> osmo arb):
         //
         // - Astro: untrn-bruhtoken @ 1.5 bruhtoken/untrn

--- a/local-interchaintest/src/main.rs
+++ b/local-interchaintest/src/main.rs
@@ -183,7 +183,6 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
                 .with_test(Box::new(tests::test_unprofitable_arb) as TestFn)
                 .build()?,
         )?
-        /*
         // Test case (astro -> osmo arb):
         //
         // - Astro: untrn-bruhtoken @ 1.5 bruhtoken/untrn
@@ -213,7 +212,7 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
                     bruhtoken_osmo.clone(),
                     Pool::Osmosis(
                         OsmosisPoolBuilder::default()
-                            .with_funds(bruhtoken_osmo.clone(), 10000000u128)
+                            .with_funds(bruhtoken_osmo.clone(), 100000000u128)
                             .with_funds(uosmo.clone(), 10000000u128)
                             .with_weight(bruhtoken_osmo.clone(), 1u128)
                             .with_weight(uosmo.clone(), 1u128)
@@ -223,16 +222,16 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
                 .with_pool(
                     untrn.clone(),
                     bruhtoken.clone(),
-                    Pool::Astroport(
-                        AstroportPoolBuilder::default()
-                            .with_balance_asset_a(10000000u128)
-                            .with_balance_asset_b(10000000u128)
+                    Pool::Auction(
+                        AuctionPoolBuilder::default()
+                            .with_balance_offer_asset(10000000u128)
+                            .with_price(Decimal::percent(10))
                             .build()?,
                     ),
                 )
                 .with_arbbot()
                 .with_test(Box::new(tests::test_osmo_arb) as TestFn)
                 .build()?,
-        )?*/
+        )?
         .join()
 }

--- a/local-interchaintest/src/main.rs
+++ b/local-interchaintest/src/main.rs
@@ -15,7 +15,7 @@ mod util;
 const TEST_MNEMONIC: &str = "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry";
 
 /// Path to a file where found arbs are stored
-const ARBFILE_PATH: &str = "../arbs.json";
+const ARBFILE_PATH: &str = "../arbs.db";
 
 /// The address that should principally own all contracts
 const OWNER_ADDR: &str = "neutron1hj5fveer5cjtn4wd6wstzugjfdxzl0xpznmsky";

--- a/local-interchaintest/src/setup.rs
+++ b/local-interchaintest/src/setup.rs
@@ -641,7 +641,7 @@ pub fn with_arb_bot_output(test: OwnedTestFn) -> TestResult {
     let proc_handle = Arc::new(proc);
     let proc_handle_watcher = proc_handle.clone();
     let (tx_res, rx_res) = mpsc::channel();
-    let mut finished = AtomicBool::new(false);
+    let finished = AtomicBool::new(false);
 
     let test_handle = test.clone();
 

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -144,14 +144,14 @@ pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send 
     println!("OSMOSIS BOT PROFIT: {osmo_profit}");
 
     util::assert_err(
-        "200000 + PROFIT_MARGIN > profit > 200000 - PROFIT_MARGIN",
-        9000000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 9000000 - ERROR_MARGIN_PROFIT,
+        "9500000 + PROFIT_MARGIN > profit > 9500000 - PROFIT_MARGIN",
+        9500000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 9500000 - ERROR_MARGIN_PROFIT,
         true,
     )?;
     util::assert_err(
-        "200000 + PROFIT_MARGIN > auction_profit > 200000 - PROFIT_MARGIN",
-        200000 + ERROR_MARGIN_PROFIT > auction_profit
-            && auction_profit > 200000 - ERROR_MARGIN_PROFIT,
+        "9500000 + PROFIT_MARGIN > auction_profit > 9500000 - PROFIT_MARGIN",
+        9500000 + ERROR_MARGIN_PROFIT > auction_profit
+            && auction_profit > 9500000 - ERROR_MARGIN_PROFIT,
         true,
     )?;
 

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -143,7 +143,17 @@ pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send 
     println!("AUCTION BOT PROFIT: {auction_profit}");
     println!("OSMOSIS BOT PROFIT: {osmo_profit}");
 
-    util::assert_err("osmo_profit == 9482512", osmo_profit, 9482512)?;
+    util::assert_err(
+        "200000 + PROFIT_MARGIN > profit > 200000 - PROFIT_MARGIN",
+        200000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 200000 - ERROR_MARGIN_PROFIT,
+        true,
+    )?;
+    util::assert_err(
+        "200000 + PROFIT_MARGIN > auction_profit > 200000 - PROFIT_MARGIN",
+        200000 + ERROR_MARGIN_PROFIT > auction_profit
+            && auction_profit > 200000 - ERROR_MARGIN_PROFIT,
+        true,
+    )?;
 
     Ok(())
 }

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -143,7 +143,7 @@ pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send 
     println!("AUCTION BOT PROFIT: {auction_profit}");
     println!("OSMOSIS BOT PROFIT: {osmo_profit}");
 
-    util::assert_err("osmo_profit == 0", osmo_profit, 0)?;
+    util::assert_err("osmo_profit == 9482512", osmo_profit, 9482512)?;
 
     Ok(())
 }

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -145,7 +145,7 @@ pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send 
 
     util::assert_err(
         "200000 + PROFIT_MARGIN > profit > 200000 - PROFIT_MARGIN",
-        200000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 200000 - ERROR_MARGIN_PROFIT,
+        9000000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 9000000 - ERROR_MARGIN_PROFIT,
         true,
     )?;
     util::assert_err(

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -89,6 +89,54 @@ pub fn test_unprofitable_arb() -> Result<(), Box<dyn Error + Send + Sync + 'stat
     Ok(())
 }
 
+pub fn test_unprofitable_osmo_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let conn = sqlite::open(ARBFILE_PATH).expect("failed to open db");
+
+    let profit = {
+        let query = "SELECT SUM(o.realized_profit) AS total_profit FROM orders o";
+
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let auction_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid WHERE l.kind = 'auction' GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let osmo_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid WHERE l.kind = 'osmosis' GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    println!("ARB BOT PROFIT: {profit}");
+    println!("AUCTION BOT PROFIT: {auction_profit}");
+    println!("OSMOSIS BOT PROFIT: {osmo_profit}");
+
+    util::assert_err("profit == 0", profit == 0, true)?;
+    util::assert_err("osmo_profit == 0", osmo_profit == 0, true)?;
+    util::assert_err("auction_profit == 0", auction_profit == 0, true)?;
+
+    Ok(())
+}
+
 pub fn test_osmo_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let conn = sqlite::open(ARBFILE_PATH).expect("failed to open db");
 
@@ -105,7 +153,7 @@ pub fn test_osmo_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     };
 
     let auction_profit = {
-        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o WHERE l.kind = 'auction' INNER JOIN legs l ON o.uid == l.order_uid GROUP BY o.uid)";
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid WHERE l.kind = 'auction' GROUP BY o.uid)";
         let mut statement = conn.prepare(query).unwrap();
 
         statement
@@ -116,7 +164,7 @@ pub fn test_osmo_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     };
 
     let osmo_profit = {
-        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o WHERE l.kind = 'osmosis' INNER JOIN legs l ON o.uid == l.order_uid GROUP BY o.uid)";
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid WHERE l.kind = 'osmosis' GROUP BY o.uid)";
         let mut statement = conn.prepare(query).unwrap();
 
         statement

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -2,8 +2,6 @@ use super::util;
 use serde_json::Value;
 use std::{error::Error, process::Command};
 
-const ERROR_MARGIN_PROFIT: u64 = 50000;
-
 pub fn test_transfer_osmosis(
     _: Option<Value>,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
@@ -56,17 +54,8 @@ pub fn test_profitable_arb(
     println!("ARB BOT PROFIT: {profit}");
     println!("AUCTION BOT PROFIT: {auction_profit}");
 
-    util::assert_err(
-        "200000 + PROFIT_MARGIN > profit > 200000 - PROFIT_MARGIN",
-        200000 + ERROR_MARGIN_PROFIT > profit && profit > 200000 - ERROR_MARGIN_PROFIT,
-        true,
-    )?;
-    util::assert_err(
-        "200000 + PROFIT_MARGIN > auction_profit > 200000 - PROFIT_MARGIN",
-        200000 + ERROR_MARGIN_PROFIT > auction_profit
-            && auction_profit > 200000 - ERROR_MARGIN_PROFIT,
-        true,
-    )?;
+    util::assert_err("profit > 0", profit > 0, true)?;
+    util::assert_err("auction_profit > 0", auction_profit > 0, true)?;
 
     Ok(())
 }
@@ -143,17 +132,8 @@ pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send 
     println!("AUCTION BOT PROFIT: {auction_profit}");
     println!("OSMOSIS BOT PROFIT: {osmo_profit}");
 
-    util::assert_err(
-        "9500000 + PROFIT_MARGIN > profit > 9500000 - PROFIT_MARGIN",
-        9500000 + ERROR_MARGIN_PROFIT > osmo_profit && osmo_profit > 9500000 - ERROR_MARGIN_PROFIT,
-        true,
-    )?;
-    util::assert_err(
-        "9500000 + PROFIT_MARGIN > auction_profit > 9500000 - PROFIT_MARGIN",
-        9500000 + ERROR_MARGIN_PROFIT > auction_profit
-            && auction_profit > 9500000 - ERROR_MARGIN_PROFIT,
-        true,
-    )?;
+    util::assert_err("osmo_profit > 0", osmo_profit > 0, true)?;
+    util::assert_err("auction_profit > 0", auction_profit > 0, true)?;
 
     Ok(())
 }

--- a/local-interchaintest/src/tests.rs
+++ b/local-interchaintest/src/tests.rs
@@ -1,10 +1,7 @@
-use super::util;
-use serde_json::Value;
+use super::{util, ARBFILE_PATH};
 use std::{error::Error, process::Command};
 
-pub fn test_transfer_osmosis(
-    _: Option<Value>,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+pub fn test_transfer_osmosis() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Command::new("python")
         .current_dir("tests")
         .arg("transfer_osmosis.py")
@@ -13,9 +10,7 @@ pub fn test_transfer_osmosis(
     Ok(())
 }
 
-pub fn test_transfer_neutron(
-    _: Option<Value>,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+pub fn test_transfer_neutron() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Command::new("python")
         .current_dir("tests")
         .arg("transfer_neutron.py")
@@ -24,32 +19,31 @@ pub fn test_transfer_neutron(
     Ok(())
 }
 
-pub fn test_profitable_arb(
-    arbfile: Option<Value>,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let arbfile = arbfile.unwrap();
-    let arbs = arbfile.as_array().expect("no arbs in arbfile");
+pub fn test_profitable_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let conn = sqlite::open(ARBFILE_PATH).expect("failed to open db");
 
-    util::assert_err("!arbs.is_empty()", arbs.is_empty(), false)?;
+    let profit = {
+        let query = "SELECT SUM(o.realized_profit) AS total_profit FROM orders o";
 
-    let profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter_map(|arb_str| {
-            serde_json::from_str::<Value>(arb_str)
-                .ok()?
-                .get("realized_profit")?
-                .as_number()?
-                .as_u64()
-        })
-        .sum();
-    let auction_profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter(|arb_str| arb_str.contains("auction"))
-        .filter_map(|arb_str| serde_json::from_str::<Value>(arb_str).ok())
-        .filter_map(|arb| arb.get("realized_profit")?.as_number()?.as_u64())
-        .sum();
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let auction_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
 
     println!("ARB BOT PROFIT: {profit}");
     println!("AUCTION BOT PROFIT: {auction_profit}");
@@ -60,78 +54,83 @@ pub fn test_profitable_arb(
     Ok(())
 }
 
-pub fn test_unprofitable_arb(
-    arbfile: Option<Value>,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let arbfile = arbfile.unwrap();
-    let arbs = arbfile.as_array().expect("no arbs in arbfile");
+pub fn test_unprofitable_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let conn = sqlite::open(ARBFILE_PATH).expect("failed to open db");
 
-    util::assert_err("!arbs.is_empty()", arbs.is_empty(), false)?;
+    let profit = {
+        let query = "SELECT SUM(o.realized_profit) AS total_profit FROM orders o";
 
-    let profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter_map(|arb_str| {
-            serde_json::from_str::<Value>(arb_str)
-                .ok()?
-                .get("realized_profit")?
-                .as_number()?
-                .as_u64()
-        })
-        .sum();
-    let auction_profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter(|arb_str| arb_str.contains("auction"))
-        .filter_map(|arb_str| serde_json::from_str::<Value>(arb_str).ok())
-        .filter_map(|arb| arb.get("realized_profit")?.as_number()?.as_u64())
-        .sum();
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let auction_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o INNER JOIN legs l ON o.uid = l.order_uid GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
 
     println!("ARB BOT PROFIT: {profit}");
     println!("AUCTION BOT PROFIT: {auction_profit}");
 
-    util::assert_err("profit == 0", profit, 0)?;
-    util::assert_err("auction_profit == 0", auction_profit, 0)?;
+    util::assert_err("profit == 0", profit == 0, true)?;
+    util::assert_err("auction_profit == 0", auction_profit == 0, true)?;
 
     Ok(())
 }
 
-pub fn test_osmo_arb(arbfile: Option<Value>) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let arbfile = arbfile.unwrap();
-    let arbs = arbfile.as_array().expect("no arbs in arbfile");
+pub fn test_osmo_arb() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let conn = sqlite::open(ARBFILE_PATH).expect("failed to open db");
 
-    util::assert_err("!arbs.is_empty()", arbs.is_empty(), false)?;
+    let profit = {
+        let query = "SELECT SUM(o.realized_profit) AS total_profit FROM orders o";
 
-    let profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter_map(|arb_str| {
-            serde_json::from_str::<Value>(arb_str)
-                .ok()?
-                .get("realized_profit")?
-                .as_number()?
-                .as_u64()
-        })
-        .sum();
-    let auction_profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter(|arb_str| arb_str.contains("auction"))
-        .filter_map(|arb_str| serde_json::from_str::<Value>(arb_str).ok())
-        .filter_map(|arb| arb.get("realized_profit")?.as_number()?.as_u64())
-        .sum();
-    let osmo_profit: u64 = arbs
-        .iter()
-        .filter_map(|arb_str| arb_str.as_str())
-        .filter(|arb_str| arb_str.contains("osmosis"))
-        .filter_map(|arb_str| serde_json::from_str::<Value>(arb_str).ok())
-        .filter_map(|arb| arb.get("realized_profit")?.as_number()?.as_u64())
-        .sum();
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let auction_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o WHERE l.kind = 'auction' INNER JOIN legs l ON o.uid == l.order_uid GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
+
+    let osmo_profit = {
+        let query = "SELECT SUM(order_profit) AS total_profit FROM (SELECT MAX(o.realized_profit) AS order_profit FROM orders o WHERE l.kind = 'osmosis' INNER JOIN legs l ON o.uid == l.order_uid GROUP BY o.uid)";
+        let mut statement = conn.prepare(query).unwrap();
+
+        statement
+            .next()
+            .ok()
+            .and_then(|_| statement.read::<i64, _>("total_profit").ok())
+            .unwrap_or_default()
+    };
 
     println!("ARB BOT PROFIT: {profit}");
     println!("AUCTION BOT PROFIT: {auction_profit}");
     println!("OSMOSIS BOT PROFIT: {osmo_profit}");
 
+    util::assert_err("profit > 0", profit > 0, true)?;
     util::assert_err("osmo_profit > 0", osmo_profit > 0, true)?;
     util::assert_err("auction_profit > 0", auction_profit > 0, true)?;
 

--- a/local-interchaintest/src/util.rs
+++ b/local-interchaintest/src/util.rs
@@ -1,12 +1,89 @@
 use serde::Serialize;
 use std::{collections::HashMap, error::Error, fmt::Debug, fs::OpenOptions, io::Write};
 
+#[derive(Clone, Serialize)]
+pub(crate) struct ChainInfo {
+    pub(crate) chain_name: String,
+    pub(crate) chain_id: String,
+    pub(crate) pfm_enabled: bool,
+    pub(crate) supports_memo: bool,
+    pub(crate) bech32_prefix: String,
+    pub(crate) fee_asset: String,
+    pub(crate) chain_type: String,
+    pub(crate) pretty_name: String,
+}
+
 #[derive(Serialize)]
-pub struct DenomMapEntry {
-    pub chain_id: String,
-    pub denom: String,
-    pub channel_id: String,
-    pub port_id: String,
+pub(crate) struct DenomChainInfo {
+    pub(crate) denom: String,
+    pub(crate) src_chain_id: String,
+    pub(crate) dest_chain_id: String,
+}
+
+#[derive(Serialize, Clone)]
+pub(crate) struct BidirectionalDenomRouteLeg {
+    pub(crate) src_to_dest: DenomRouteLeg,
+    pub(crate) dest_to_src: DenomRouteLeg,
+}
+
+#[derive(Serialize, Clone)]
+pub(crate) struct DenomRouteLeg {
+    pub(crate) src_chain: String,
+    pub(crate) dest_chain: String,
+    pub(crate) src_denom: String,
+    pub(crate) dest_denom: String,
+    pub(crate) from_chain: ChainInfo,
+    pub(crate) to_chain: ChainInfo,
+    pub(crate) port: String,
+    pub(crate) channel: String,
+}
+
+impl From<DenomRouteLeg> for DenomChainInfo {
+    fn from(v: DenomRouteLeg) -> Self {
+        Self {
+            denom: v.dest_denom,
+            src_chain_id: v.src_chain,
+            dest_chain_id: v.dest_chain,
+        }
+    }
+}
+
+#[derive(Serialize, Default)]
+pub(crate) struct DenomFile {
+    pub(crate) denom_map: HashMap<String, Vec<DenomChainInfo>>,
+    pub(crate) denom_routes: HashMap<String, HashMap<String, Vec<DenomRouteLeg>>>,
+    pub(crate) chain_info: HashMap<String, ChainInfo>,
+}
+
+impl DenomFile {
+    /// Registers a denom in the denom file by adding its
+    /// matching denoms on all respective chains,
+    /// and the routes needed to get here.
+    pub fn push_denom(&mut self, v: BidirectionalDenomRouteLeg) -> &mut Self {
+        self.denom_map
+            .entry(v.src_to_dest.src_denom.clone())
+            .or_default()
+            .push(v.src_to_dest.clone().into());
+        self.denom_routes
+            .entry(v.src_to_dest.src_denom.clone())
+            .or_default()
+            .entry(v.src_to_dest.dest_denom.clone())
+            .or_default()
+            .push(v.src_to_dest);
+
+        self.denom_map
+            .entry(v.dest_to_src.src_denom.clone())
+            .or_default()
+            .push(v.dest_to_src.clone().into());
+        self.denom_routes
+            .entry(v.dest_to_src.src_denom.clone())
+            .or_default()
+            .entry(v.dest_to_src.clone().dest_denom)
+            .or_default()
+            .push(v.dest_to_src);
+
+        self
+    }
 }
 
 /// Creates an error representing a failed assertion.
@@ -130,24 +207,14 @@ pub(crate) fn create_netconfig() -> Result<(), Box<dyn Error + Send + Sync>> {
     Ok(())
 }
 
-pub(crate) fn create_denom_file(
-    denoms: &HashMap<(String, String), DenomMapEntry>,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub(crate) fn create_denom_file(file: &DenomFile) -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut f = OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
         .open("../denoms.json")?;
 
-    let denoms_for_src =
-        denoms
-            .iter()
-            .fold(HashMap::new(), |mut acc, ((src_denom, _), dest_denom)| {
-                acc.insert(src_denom, vec![dest_denom]);
-                acc
-            });
-
-    f.write_all(serde_json::to_string(&denoms_for_src)?.as_bytes())?;
+    f.write_all(serde_json::to_string(file)?.as_bytes())?;
 
     Ok(())
 }

--- a/local-interchaintest/src/util.rs
+++ b/local-interchaintest/src/util.rs
@@ -175,9 +175,9 @@ pub(crate) fn create_arbs_file() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create(true)
         .truncate(true)
         .write(true)
-        .open("../arbs.json")?;
+        .open("../arbs.db")?;
 
-    f.write_all(serde_json::json!([]).to_string().as_bytes())?;
+    f.write_all(&[])?;
 
     Ok(())
 }

--- a/local-interchaintest/tests/transfer_neutron.py
+++ b/local-interchaintest/tests/transfer_neutron.py
@@ -1,5 +1,6 @@
 import json
 import asyncio
+from asyncio import Lock
 from typing import Any
 from src.strategies.util import transfer_raw
 from src.scheduler import Ctx
@@ -48,6 +49,7 @@ async def main() -> None:
             denoms,
             {},
             {},
+            Lock(),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_neutron.py
+++ b/local-interchaintest/tests/transfer_neutron.py
@@ -1,9 +1,9 @@
 import json
 import asyncio
-from asyncio import Lock
+from asyncio import Semaphore
 from typing import Any
 from src.strategies.util import transfer_raw
-from src.scheduler import Ctx
+from src.scheduler import Ctx, MAX_SKIP_CONCURRENT_CALLS
 from src.util import try_multiple_clients
 from src.util import custom_neutron_network_config
 import aiohttp
@@ -49,7 +49,7 @@ async def main() -> None:
             denoms,
             {},
             {},
-            Lock(),
+            Semaphore(MAX_SKIP_CONCURRENT_CALLS),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_neutron.py
+++ b/local-interchaintest/tests/transfer_neutron.py
@@ -4,7 +4,10 @@ import asyncio
 from asyncio import Semaphore
 from typing import Any
 from src.strategies.util import transfer_raw
-from src.scheduler import Ctx, MAX_SKIP_CONCURRENT_CALLS
+from src.scheduler import (
+    Ctx,
+    MAX_SKIP_CONCURRENT_CALLS,
+)
 from src.util import try_multiple_clients
 from src.util import custom_neutron_network_config
 import aiohttp

--- a/local-interchaintest/tests/transfer_neutron.py
+++ b/local-interchaintest/tests/transfer_neutron.py
@@ -1,3 +1,4 @@
+from sqlite3 import connect
 import json
 import asyncio
 from asyncio import Semaphore
@@ -50,6 +51,7 @@ async def main() -> None:
             {},
             {},
             Semaphore(MAX_SKIP_CONCURRENT_CALLS),
+            connect("test_db.db"),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_neutron.py
+++ b/local-interchaintest/tests/transfer_neutron.py
@@ -46,6 +46,8 @@ async def main() -> None:
             [],
             {},
             denoms,
+            {},
+            {},
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_osmosis.py
+++ b/local-interchaintest/tests/transfer_osmosis.py
@@ -1,4 +1,5 @@
 import json
+from asyncio import Lock
 import asyncio
 from typing import Any
 from src.strategies.util import transfer_raw
@@ -48,6 +49,7 @@ async def main() -> None:
             denoms,
             {},
             {},
+            Lock(),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_osmosis.py
+++ b/local-interchaintest/tests/transfer_osmosis.py
@@ -4,7 +4,10 @@ from asyncio import Semaphore
 import asyncio
 from typing import Any
 from src.strategies.util import transfer_raw
-from src.scheduler import Ctx, MAX_SKIP_CONCURRENT_CALLS
+from src.scheduler import (
+    Ctx,
+    MAX_SKIP_CONCURRENT_CALLS,
+)
 from src.util import try_multiple_clients
 from src.util import custom_neutron_network_config
 import aiohttp

--- a/local-interchaintest/tests/transfer_osmosis.py
+++ b/local-interchaintest/tests/transfer_osmosis.py
@@ -1,3 +1,4 @@
+from sqlite3 import connect
 import json
 from asyncio import Semaphore
 import asyncio
@@ -50,6 +51,7 @@ async def main() -> None:
             {},
             {},
             Semaphore(MAX_SKIP_CONCURRENT_CALLS),
+            connect("test_db.db"),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_osmosis.py
+++ b/local-interchaintest/tests/transfer_osmosis.py
@@ -1,9 +1,9 @@
 import json
-from asyncio import Lock
+from asyncio import Semaphore
 import asyncio
 from typing import Any
 from src.strategies.util import transfer_raw
-from src.scheduler import Ctx
+from src.scheduler import Ctx, MAX_SKIP_CONCURRENT_CALLS
 from src.util import try_multiple_clients
 from src.util import custom_neutron_network_config
 import aiohttp
@@ -49,7 +49,7 @@ async def main() -> None:
             denoms,
             {},
             {},
-            Lock(),
+            Semaphore(MAX_SKIP_CONCURRENT_CALLS),
         )
 
         await transfer_raw(

--- a/local-interchaintest/tests/transfer_osmosis.py
+++ b/local-interchaintest/tests/transfer_osmosis.py
@@ -46,6 +46,8 @@ async def main() -> None:
             [],
             {},
             denoms,
+            {},
+            {},
         )
 
         await transfer_raw(

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ import logging
 import sys
 from os import path
 import os
-from typing import Any, cast, Optional
+from typing import Any, cast
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from src.scheduler import Scheduler, Ctx
@@ -105,12 +105,16 @@ async def main() -> None:
                 f,
             )
 
-    denom_map: Optional[dict[str, list[dict[str, str]]]] = None
+    denom_file: dict[str, Any] = {
+        "denom_map": {},
+        "denom_routes": {},
+        "chain_info": {},
+    }
 
     # If the user has specified a denom map, use that instead of skip
     if args.denom_file is not None and path.isfile(args.denom_file):
         with open(args.denom_file, "r", encoding="utf-8") as f:
-            denom_map = json.load(f)
+            denom_file = json.load(f)
 
     # If the user specified a poolfile, create the poolfile if it is empty
     if args.pool_file is not None and not path.isfile(args.pool_file):
@@ -188,7 +192,9 @@ async def main() -> None:
                 session,
                 [],
                 cast(dict[str, Any], json.load(f)),
-                denom_map,
+                denom_file["denom_map"],
+                denom_file["denom_routes"],
+                denom_file["chain_info"],
             ).recover_history()
             sched = Scheduler(ctx, strategy)
 

--- a/main.py
+++ b/main.py
@@ -156,7 +156,7 @@ async def main() -> None:
             connector=aiohttp.TCPConnector(
                 force_close=True, limit_per_host=DISCOVERY_CONCURRENCY_FACTOR
             ),
-            timeout=aiohttp.ClientTimeout(total=240),
+            timeout=aiohttp.ClientTimeout(total=60),
         ) as session:
             ctx: Ctx[Any] = Ctx(
                 {

--- a/main.py
+++ b/main.py
@@ -154,7 +154,7 @@ async def main() -> None:
             connector=aiohttp.TCPConnector(
                 force_close=True, limit_per_host=DISCOVERY_CONCURRENCY_FACTOR
             ),
-            timeout=aiohttp.ClientTimeout(total=30),
+            timeout=aiohttp.ClientTimeout(total=90),
         ) as session:
             ctx: Ctx[Any] = Ctx(
                 {

--- a/main.py
+++ b/main.py
@@ -78,6 +78,7 @@ async def main() -> None:
         "-df", "--deployments_file", default="contracts/deployments.json"
     )
     parser.add_argument("-rt", "--rebalance_threshold", default=1000)
+    parser.add_argument("-lr", "--log_rebalancing", default=False)
     parser.add_argument("cmd", nargs="*", default=None)
 
     args = parser.parse_args()
@@ -189,6 +190,7 @@ async def main() -> None:
                         if "SKIP_API_KEY" in os.environ
                         else None
                     ),
+                    "log_rebalancing": args.log_rebalancing,
                 },
                 None,
                 False,

--- a/main.py
+++ b/main.py
@@ -155,7 +155,7 @@ async def main() -> None:
             connector=aiohttp.TCPConnector(
                 force_close=True, limit_per_host=DISCOVERY_CONCURRENCY_FACTOR
             ),
-            timeout=aiohttp.ClientTimeout(total=90),
+            timeout=aiohttp.ClientTimeout(total=240),
         ) as session:
             ctx: Ctx[Any] = Ctx(
                 {

--- a/main.py
+++ b/main.py
@@ -149,7 +149,7 @@ async def main() -> None:
             ),
             timeout=aiohttp.ClientTimeout(total=60),
         ) as session:
-            with closing(connect(args.history_db, autocommit=False)) as conn:
+            with closing(connect(args.history_db)) as conn:
                 ctx: Ctx[Any] = Ctx(
                     {
                         chain_id: [

--- a/main.py
+++ b/main.py
@@ -19,7 +19,11 @@ import os
 from typing import Any, cast
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
-from src.scheduler import Scheduler, Ctx, MAX_SKIP_CONCURRENT_CALLS
+from src.scheduler import (
+    Scheduler,
+    Ctx,
+    MAX_SKIP_CONCURRENT_CALLS,
+)
 from src.util import (
     custom_neutron_network_config,
     DISCOVERY_CONCURRENCY_FACTOR,
@@ -90,7 +94,7 @@ async def main() -> None:
             format="%(asctime)s %(levelname)-8s %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
             filename=args.log_file,
-            level=os.environ.get("LOGLEVEL", "INFO").upper(),
+            level=os.environ.get("LOGLEVEL", "info").upper(),
         )
 
     else:
@@ -98,7 +102,7 @@ async def main() -> None:
             format="%(asctime)s %(levelname)-8s %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
             stream=sys.stdout,
-            level=os.environ.get("LOGLEVEL", "INFO").upper(),
+            level=os.environ.get("LOGLEVEL", "info").upper(),
         )
 
     denom_file: dict[str, Any] = {

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 Implements a command-line interface for running arbitrage strategies.
 """
 
-from asyncio import Lock
+from asyncio import Semaphore
 import traceback
 import asyncio
 from multiprocessing import Process
@@ -215,7 +215,7 @@ async def main() -> None:
                     chain_id: load_chain_info(info)
                     for (chain_id, info) in denom_file["chain_info"].items()
                 },
-                Lock(),
+                Semaphore(),
             ).recover_history()
             sched = Scheduler(ctx, strategy)
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import os
 from typing import Any, cast
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
-from src.scheduler import Scheduler, Ctx
+from src.scheduler import Scheduler, Ctx, MAX_SKIP_CONCURRENT_CALLS
 from src.util import (
     custom_neutron_network_config,
     DISCOVERY_CONCURRENCY_FACTOR,
@@ -215,7 +215,7 @@ async def main() -> None:
                     chain_id: load_chain_info(info)
                     for (chain_id, info) in denom_file["chain_info"].items()
                 },
-                Semaphore(),
+                Semaphore(MAX_SKIP_CONCURRENT_CALLS),
             ).recover_history()
             sched = Scheduler(ctx, strategy)
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
 Implements a command-line interface for running arbitrage strategies.
 """
 
+from asyncio import Lock
 import traceback
 import asyncio
 from multiprocessing import Process
@@ -214,6 +215,7 @@ async def main() -> None:
                     chain_id: load_chain_info(info)
                     for (chain_id, info) in denom_file["chain_info"].items()
                 },
+                Lock(),
             ).recover_history()
             sched = Scheduler(ctx, strategy)
 

--- a/src/contracts/pool/astroport.py
+++ b/src/contracts/pool/astroport.py
@@ -254,7 +254,7 @@ class NeutronAstroportPoolProvider(PoolProvider, WithContract):
 
         balance = next(b for b in balances if b["info"] == token_to_asset_info(asset))
 
-        if not balance:
+        if balance is None:
             return 0
 
         return int(balance["amount"])

--- a/src/contracts/pool/astroport.py
+++ b/src/contracts/pool/astroport.py
@@ -31,7 +31,7 @@ from cosmpy.crypto.address import Address
 from cosmpy.aerial.tx import Transaction
 
 
-MAX_SPREAD = "0.05"
+MAX_SPREAD = "0.1"
 
 
 @dataclass

--- a/src/contracts/route.py
+++ b/src/contracts/route.py
@@ -61,6 +61,7 @@ class Route:
     status: Status
     time_created: str
     logs: list[str]
+    logs_enabled: bool
 
     def __hash__(self) -> int:
         return hash(self.uid)
@@ -113,6 +114,7 @@ def load_route(s: str) -> Route:
         Status[loaded["status"].split(".")[1]],
         loaded["time_created"],
         loaded["logs"],
+        True,
     )
 
 

--- a/src/contracts/route.py
+++ b/src/contracts/route.py
@@ -53,6 +53,7 @@ class Route:
 
     uid: int
     route: list[LegRepr]
+    legs: list[Leg]
     theoretical_profit: int
     expected_profit: int
     realized_profit: Optional[int]
@@ -104,6 +105,7 @@ def load_route(s: str) -> Route:
     return Route(
         loaded["uid"],
         [load_leg_repr(json_leg) for json_leg in loaded["route"]],
+        [],
         loaded["theoretical_profit"],
         loaded["expected_profit"],
         loaded["realized_profit"],

--- a/src/contracts/route.py
+++ b/src/contracts/route.py
@@ -40,6 +40,7 @@ class LegRepr:
     out_asset: str
     kind: str
     executed: bool
+    execution_height: Optional[int]
 
     def __str__(self) -> str:
         return f"{self.kind}: {self.in_asset} -> {self.out_asset}"
@@ -114,6 +115,7 @@ class Route:
                     leg.out_asset(),
                     leg_repr.kind,
                     leg_repr.executed,
+                    leg_repr.execution_height,
                 ]
             )
 

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,109 @@
+from sqlite3 import Cursor
+from typing import Any
+
+
+def order_row_count(cur: Cursor) -> int:
+    """
+    Gets the number of orders in the database.
+    """
+
+    res = cur.execute("SELECT COUNT(*) AS cnt FROM orders")
+
+    (cnt,) = res.fetchone()
+
+    return int(cnt)
+
+
+def insert_order_rows(cur: Cursor, rows: list[list[Any]]) -> None:
+    """
+    Inserts a new row into orders for each order row.
+    Does not commit the transaction.
+    """
+
+    cur.executemany(
+        """INSERT INTO orders(
+        theoretical_profit,
+        expected_profit,
+        realized_profit,
+        status,
+        time_created,
+        logs_enabled
+        ) VALUES (?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+
+
+def insert_legs_rows(cur: Cursor, rows: list[list[Any]]) -> None:
+    """
+    Inserts a new row into legs for each leg row.
+    Does not commit the transaction.
+    """
+
+    cur.executemany(
+        """INSERT INTO legs(
+        route_index,
+        order_uid,
+        in_amount,
+        out_amount,
+        in_asset,
+        out_asset,
+        kind,
+        executed
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+
+
+def insert_logs_rows(cur: Cursor, rows: list[tuple[int, int, str]]) -> None:
+    """
+    Inserts a new row for each log row.
+    Does not commit the transaction.
+    """
+
+    cur.executemany(
+        "INSERT INTO logs(log_index, order_uid, contents) VALUES (?, ?, ?)", rows
+    )
+
+
+def migrate(cur: Cursor) -> None:
+    """
+    Creates requisite tables in the on-disk db in case they do not already exist.
+    Does not commit the transaction.
+    """
+
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS orders(
+        uid INTEGER NOT NULL PRIMARY KEY,
+        theoretical_profit TEXT NOT NULL,
+        expected_profit TEXT NOT NULL,
+        realized_profit TEXT,
+        status TEXT NOT NULL,
+        time_created DATETIME NOT NULL,
+        logs_enabled BOOL NOT NULL
+        )"""
+    )
+
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS legs(
+        route_index INTEGER NOT NULL,
+        order_uid INTEGER NOT NULL,
+        in_amount TEXT NOT NULL,
+        out_amount TEXT,
+        in_asset TEXT NOT NULL,
+        out_asset TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        executed BOOL NOT NULL,
+        PRIMARY KEY (route_index, order_uid),
+        FOREIGN KEY(order_uid) REFERENCES orders(uid)
+        )"""
+    )
+
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS logs(
+        log_index INTEGER NOT NULL,
+        order_uid INTEGER NOT NULL,
+        contents TEXT NOT NULL,
+        PRIMARY KEY (log_index, order_uid),
+        FOREIGN KEY(order_uid) REFERENCES orders(uid)
+        )"""
+    )

--- a/src/db.py
+++ b/src/db.py
@@ -48,8 +48,9 @@ def insert_legs_rows(cur: Cursor, rows: list[list[Any]]) -> None:
         in_asset,
         out_asset,
         kind,
-        executed
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        executed,
+        execution_height
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         rows,
     )
 
@@ -93,6 +94,7 @@ def migrate(cur: Cursor) -> None:
         out_asset TEXT NOT NULL,
         kind TEXT NOT NULL,
         executed BOOL NOT NULL,
+        execution_height INTEGER,
         PRIMARY KEY (route_index, order_uid),
         FOREIGN KEY(order_uid) REFERENCES orders(uid)
         )"""

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -106,6 +106,7 @@ class Ctx(Generic[TState]):
         theoretical_profit: int,
         expected_profit: int,
         quantities: list[int],
+        enable_logs: bool = True,
     ) -> Route:
         """
         Creates a new identified route, inserting it into the order history,
@@ -126,6 +127,7 @@ class Ctx(Generic[TState]):
             Status.QUEUED,
             datetime.now().strftime("%Y-%m-%d @ %H:%M:%S"),
             [],
+            enable_logs,
         )
         self.order_history.append(r)
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -153,7 +153,7 @@ class Ctx(Generic[TState]):
         )
 
         if balance_resp_in:
-            prefix += f"BALANCE[{route.legs[0].in_asset()[:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_in} "
+            prefix += f"balance[{route.legs[0].in_asset()[:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_in} "
 
         balance_resp_base_denom = try_multiple_clients(
             self.clients[route.legs[0].backend.chain_id],
@@ -166,7 +166,7 @@ class Ctx(Generic[TState]):
         )
 
         if balance_resp_base_denom:
-            prefix += f"BALANCE[{self.cli_args['base_denom'][:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_in} "
+            prefix += f"balance[{self.cli_args['base_denom'][:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_in} "
 
         route.logs.append(f"{log_level.upper()} {prefix}{fmt_string % tuple(args)}")
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -116,9 +116,6 @@ class Ctx(Generic[TState]):
 
         return self
 
-    def refresh_denom_balances(self) -> None:
-        self.denom_balance_cache.clear()
-
     def cancel(self) -> Self:
         """
         Marks the event loop for termination.
@@ -249,11 +246,6 @@ class Ctx(Generic[TState]):
         Gets the balance of the denom on the given chain.
         """
 
-        denom_id = f"{denom}_{chain_id}"
-
-        if denom_id in self.denom_balance_cache:
-            return self.denom_balance_cache[denom_id]
-
         balance_resp_asset = try_multiple_clients(
             self.clients[chain_id],
             lambda client: client.query_bank_balance(
@@ -266,11 +258,7 @@ class Ctx(Generic[TState]):
         )
 
         if balance_resp_asset is None or not isinstance(balance_resp_asset, int):
-            self.denom_balance_cache[denom_id] = 0
-
             return 0
-
-        self.denom_balance_cache[denom_id] = int(balance_resp_asset)
 
         return int(balance_resp_asset)
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -166,12 +166,18 @@ class Ctx(Generic[TState]):
             return f"balance[{leg.backend.chain_id}]({asset[:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}): {balance_resp_asset}"
 
         def leg_balance_prefixes(leg: Leg) -> list[str]:
+            """
+            Get the chain, denom, and denom balance for the in and out assets in the leg.
+            """
+
             assets = [leg.in_asset(), leg.out_asset()]
 
             return [
                 x for x in (asset_balance_prefix(leg, asset) for asset in assets) if x
             ]
 
+        # Log all in and out asset balances for each leg in the route,
+        # removing any duplicate prefixes using dict.fromkeys
         prefix = " ".join(
             list(
                 dict.fromkeys(

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -268,9 +268,12 @@ class Ctx(Generic[TState]):
                 from_chain_info = await self.query_chain_info(
                     transfer_info["from_chain_id"]
                 )
+                print("here", transfer_info["to_chain_id"])
                 to_chain_info = await self.query_chain_info(
                     transfer_info["to_chain_id"]
                 )
+
+                print(to_chain_info)
 
                 if not from_chain_info or not to_chain_info:
                     return None

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -365,7 +365,11 @@ class Ctx(Generic[TState]):
                     src_chain_id=src_chain, denom=info["denom"], dest_chain_id=chain_id
                 )
 
-            return [chain_info(chain_id, info) for chain_id, info in dests.items()]
+            infos = [chain_info(chain_id, info) for chain_id, info in dests.items()]
+
+            self.denom_map[src_denom] = infos
+
+            return infos
 
 
 class Scheduler(Generic[TState]):

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -141,7 +141,7 @@ class Ctx(Generic[TState]):
         r = Route(
             len(self.order_history),
             [
-                LegRepr(leg.in_asset(), leg.out_asset(), leg.backend.kind, False)
+                LegRepr(leg.in_asset(), leg.out_asset(), leg.backend.kind, False, None)
                 for leg in route
             ],
             route,

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -268,12 +268,9 @@ class Ctx(Generic[TState]):
                 from_chain_info = await self.query_chain_info(
                     transfer_info["from_chain_id"]
                 )
-                print("here", transfer_info["to_chain_id"])
                 to_chain_info = await self.query_chain_info(
                     transfer_info["to_chain_id"]
                 )
-
-                print(to_chain_info)
 
                 if not from_chain_info or not to_chain_info:
                     return None

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -354,7 +354,7 @@ class Ctx(Generic[TState]):
         head = {"accept": "application/json", "content-type": "application/json"}
 
         async with self.http_session.post(
-            "https://api.skip.money/v1/fungible/assets_from_source",
+            "https://api.skip.money/v2/fungible/assets_from_source",
             headers=head,
             json={
                 "allow_multi_tx": False,

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -2,7 +2,7 @@
 Implements a strategy runner with an arbitrary provider set in an event-loop style.
 """
 
-from asyncio import Lock
+from asyncio import Semaphore
 import logging
 from datetime import datetime
 import json
@@ -62,7 +62,7 @@ class Ctx(Generic[TState]):
     denom_map: dict[str, list[DenomChainInfo]]
     denom_routes: dict[str, dict[str, list[DenomRouteLeg]]]
     chain_info: dict[str, ChainInfo]
-    http_session_lock: Lock
+    http_session_lock: Semaphore
 
     def with_state(self, state: Any) -> Self:
         """

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -150,6 +150,9 @@ class Ctx(Generic[TState]):
         Writes a log to the standard logger and to the log file of a route.
         """
 
+        if not route.logs_enabled:
+            return
+
         def asset_balance_prefix(leg: Leg, asset: str) -> Optional[str]:
             balance_resp_asset = try_multiple_clients(
                 self.clients[leg.backend.chain_id],

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -166,7 +166,7 @@ class Ctx(Generic[TState]):
         )
 
         if balance_resp_base_denom:
-            prefix += f"balance[{self.cli_args['base_denom'][:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_in} "
+            prefix += f"balance[{self.cli_args['base_denom'][:DENOM_BALANCE_PREFIX_MAX_DENOM_LEN]}]: {balance_resp_base_denom} "
 
         route.logs.append(f"{log_level.upper()} {prefix}{fmt_string % tuple(args)}")
 

--- a/src/strategies/bellman_ford.py
+++ b/src/strategies/bellman_ford.py
@@ -290,7 +290,7 @@ async def strategy(
         ),
     )
 
-    if not balance_resp:
+    if balance_resp is None or not isinstance(balance_resp, int):
         return ctx
 
     profit = await route_base_denom_profit(balance_resp, route)

--- a/src/strategies/bellman_ford.py
+++ b/src/strategies/bellman_ford.py
@@ -21,7 +21,6 @@ from src.strategies.util import (
     quantities_for_route_profit,
 )
 from src.util import (
-    denom_info_on_chain,
     try_multiple_clients,
 )
 from cosmpy.crypto.address import Address
@@ -409,17 +408,15 @@ async def route_bellman_ford(
         for edge_a, edge_b in ctx.state.weights.values():
 
             async def relax_edge(edge: Edge) -> None:
-                in_asset_infos = await denom_info_on_chain(
+                in_asset_infos = await ctx.query_denom_info_on_chain(
                     edge.backend.backend.chain_id,
                     edge.backend.in_asset(),
                     "neutron-1",
-                    ctx.http_session,
                 )
-                out_asset_infos = await denom_info_on_chain(
+                out_asset_infos = await ctx.query_denom_info_on_chain(
                     edge.backend.backend.chain_id,
                     edge.backend.out_asset(),
                     "neutron-1",
-                    ctx.http_session,
                 )
 
                 if not in_asset_infos:
@@ -428,8 +425,8 @@ async def route_bellman_ford(
                 if not out_asset_infos:
                     return
 
-                in_asset = in_asset_infos[0].denom
-                out_asset = out_asset_infos[0].denom
+                in_asset = in_asset_infos.denom
+                out_asset = out_asset_infos.denom
 
                 if (
                     (
@@ -507,40 +504,36 @@ async def route_bellman_ford(
     # If this trade doesn't start and end with USDC
     # construct it to do so
     if legs[0].in_asset() != src or legs[-1].out_asset() != src:
-        in_denom = await denom_info_on_chain(
+        in_denom = await ctx.query_denom_info_on_chain(
             "neutron-1",
             src,
             legs[0].backend.chain_id,
-            ctx.http_session,
         )
 
         if not in_denom:
             return None
 
-        out_denom = await denom_info_on_chain(
+        out_denom = await ctx.query_denom_info_on_chain(
             "neutron-1",
             src,
             legs[-1].backend.chain_id,
-            ctx.http_session,
         )
 
         if not out_denom:
             return None
 
         in_legs: list[Union[PoolProvider, AuctionProvider]] = list(
-            pools.get(in_denom[0].denom, {}).get(legs[0].in_asset(), [])
+            pools.get(in_denom.denom, {}).get(legs[0].in_asset(), [])
         )
-        in_auction = auctions.get(in_denom[0].denom, {}).get(legs[0].in_asset(), None)
+        in_auction = auctions.get(in_denom.denom, {}).get(legs[0].in_asset(), None)
 
         if in_auction:
             in_legs.append(in_auction)
 
         out_legs: list[Union[PoolProvider, AuctionProvider]] = list(
-            pools.get(legs[-1].out_asset(), {}).get(out_denom[0].denom, [])
+            pools.get(legs[-1].out_asset(), {}).get(out_denom.denom, [])
         )
-        out_auction = auctions.get(legs[-1].out_asset(), {}).get(
-            out_denom[0].denom, None
-        )
+        out_auction = auctions.get(legs[-1].out_asset(), {}).get(out_denom.denom, None)
 
         if out_auction:
             out_legs.append(out_auction)
@@ -556,12 +549,12 @@ async def route_bellman_ford(
                 Leg(
                     (
                         in_leg.asset_a
-                        if in_leg.asset_a() == in_denom[0].denom
+                        if in_leg.asset_a() == in_denom.denom
                         else in_leg.asset_b
                     ),
                     (
                         in_leg.asset_b
-                        if in_leg.asset_a() == in_denom[0].denom
+                        if in_leg.asset_a() == in_denom.denom
                         else in_leg.asset_a
                     ),
                     in_leg,
@@ -572,12 +565,12 @@ async def route_bellman_ford(
                 Leg(
                     (
                         out_leg.asset_b
-                        if out_leg.asset_a() == out_denom[0].denom
+                        if out_leg.asset_a() == out_denom.denom
                         else out_leg.asset_a
                     ),
                     (
                         out_leg.asset_a
-                        if out_leg.asset_a() == out_denom[0].denom
+                        if out_leg.asset_a() == out_denom.denom
                         else out_leg.asset_b
                     ),
                     out_leg,

--- a/src/strategies/bellman_ford.py
+++ b/src/strategies/bellman_ford.py
@@ -4,7 +4,6 @@ Implements an arbitrage strategy based on bellman ford.
 
 from functools import cache
 import traceback
-import random
 import logging
 from decimal import Decimal
 import asyncio
@@ -391,7 +390,7 @@ async def route_bellman_ford(
     }
 
     if ctx.cli_args["pools"]:
-        vertices = set(random.sample(list(vertices), ctx.cli_args["pools"] - 1))
+        vertices = set(list(vertices))
 
     # How far a given denom is from the `src` denom
     distances: dict[str, Decimal] = {}

--- a/src/strategies/naive.py
+++ b/src/strategies/naive.py
@@ -63,8 +63,7 @@ class State:
             ),
         )
 
-        if balance_resp:
-            self.balance = balance_resp
+        self.balance = balance_resp
 
         return self
 
@@ -113,7 +112,7 @@ async def strategy(
     ):
         ctx.log_route(r, "info", "Route queued: %s", [fmt_route(route)])
 
-        if not state.balance:
+        if state.balance is None:
             return ctx
 
         ctx.log_route(
@@ -233,7 +232,7 @@ async def eval_route(
     if not state:
         return None
 
-    if not state.balance:
+    if state.balance is None or not isinstance(state.balance, int):
         logger.error(
             "Failed to fetch bot wallet balance for account %s",
             str(Address(ctx.wallet.public_key(), prefix="neutron")),

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -1252,7 +1252,7 @@ async def quantities_for_route_profit(
     if len(plans_by_profit) == 0:
         return (0, [])
 
-    best_plan = plans[plans_by_profit[0]]
+    best_plan = plans[plans_by_profit[-1]]
 
     ctx.log_route(
         r,

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -695,13 +695,12 @@ async def listen_routes_with_depth_dfs(
         nonlocal eval_profit
 
         if len(path) >= 2:
-            matching_denoms = [
-                info.denom
-                for info in await ctx.query_denom_info(
-                    path[-2].backend.chain_id,
-                    path[-2].out_asset(),
-                )
-            ]
+            denom_infos = await ctx.query_denom_info(
+                path[-2].backend.chain_id,
+                path[-2].out_asset(),
+            )
+
+            matching_denoms = [info.denom for info in denom_infos]
 
             if not (
                 path[-1].in_asset() == path[-2].out_asset()
@@ -1209,7 +1208,7 @@ async def quantities_for_route_profit(
                 ", ".join(
                     (
                         f"[{', '.join((str(qty) for qty in plans[plan_idx]))}]"
-                        for plan_idx in plans_by_profit[:5]
+                        for plan_idx in plans_by_profit[:-5]
                     )
                 ),
             ],
@@ -1218,11 +1217,11 @@ async def quantities_for_route_profit(
         profit = 0 if len(quantities) == 0 else quantities[-1] - quantities[0]
 
         # Insert in sorted position
-        if len(quantities) >= len(route):
+        if len(quantities) > len(route):
             insort(plans_by_profit, mid, key=lambda idx: plans[idx][-1] - plans[idx][0])
 
         # Continue checking plans, since this quantity was not profitable
-        if len(quantities) < len(route) or profit <= 0:
+        if len(quantities) <= len(route) or profit <= 0:
             right = mid
             mid = right // 2
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -3,7 +3,6 @@ Defines common utilities shared across arbitrage strategies.
 """
 
 from bisect import insort
-import random
 import traceback
 import asyncio
 from itertools import groupby
@@ -834,8 +833,6 @@ async def listen_routes_with_depth_dfs(
 
         if len(next_pools) == 0:
             return
-
-        random.shuffle(next_pools)
 
         routes = stream.merge(*[next_legs(path + [pool]) for pool in next_pools])
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -1108,7 +1108,7 @@ async def transfer_raw(
 
         # Check for a package acknowledgement by querying osmosis
         ack_resp = await try_multiple_rest_endpoints(
-            ctx.endpoints[dest_chain_id]["http"],
+            ctx.endpoints[src_chain_id]["http"],
             (
                 f"/ibc/core/channel/v1/channels/{src_channel_id}/"
                 f"ports/transfer/packet_acks/"

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -469,7 +469,7 @@ async def exec_arb(
                 executed_leg.executed = True
 
                 # Update the execution height if it can be found
-                resp = tx.response()
+                resp = tx.response
 
                 if resp:
                     executed_leg.execution_height = resp.height
@@ -543,7 +543,7 @@ async def exec_arb(
         executed_leg.executed = True
 
         # Update the execution height if it can be found
-        resp = tx.response()
+        resp = tx.response
 
         if resp:
             executed_leg.execution_height = resp.height

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -2,7 +2,6 @@
 Defines common utilities shared across arbitrage strategies.
 """
 
-from bisect import insort
 import traceback
 import asyncio
 from itertools import groupby
@@ -920,9 +919,7 @@ async def recover_funds(
 
     profit, quantities = resp
 
-    r = ctx.queue_route(
-        backtracked, -r.theoretical_profit, -r.expected_profit, quantities
-    )
+    r = ctx.queue_route(backtracked, 0, 0, quantities)
 
     ctx.log_route(r, "info", "Executing recovery", [])
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -458,13 +458,21 @@ async def exec_arb(
             )
 
             for leg, _ in sublegs:
-                next(
+                executed_leg = next(
                     (
                         leg_repr
                         for leg_repr in route_ent.route
                         if str(leg_repr) == str(leg)
                     )
-                ).executed = True
+                )
+
+                executed_leg.executed = True
+
+                # Update the execution height if it can be found
+                resp = tx.response()
+
+                if resp:
+                    executed_leg.execution_height = resp.height
 
                 prev_leg = leg
 
@@ -528,9 +536,17 @@ async def exec_arb(
                 ],
             )
 
-        next(
+        executed_leg = next(
             (leg_repr for leg_repr in route_ent.route if str(leg_repr) == str(leg))
-        ).executed = True
+        )
+
+        executed_leg.executed = True
+
+        # Update the execution height if it can be found
+        resp = tx.response()
+
+        if resp:
+            executed_leg.execution_height = resp.height
 
         prev_leg = leg
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -964,15 +964,15 @@ async def transfer(
         )
     )
 
+    if not ibc_route or len(ibc_route) == 0:
+        raise ValueError(f"No route from {denom} to {leg.backend.chain_id}")
+
     ctx.log_route(
         route,
         "info",
         "Got potential transfer route: %s",
         [fmt_denom_route_leg(leg) for leg in ibc_route],
     )
-
-    if not ibc_route or len(ibc_route) == 0:
-        raise ValueError(f"No route from {denom} to {leg.backend.chain_id}")
 
     src_channel_id = ibc_route[0].channel
     sender_addr = str(

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -1249,7 +1249,7 @@ async def quantities_for_route_profit(
         # Continue checking plans, since this quantity was not profitable
         if len(quantities) <= len(route) or profit <= 0:
             right = mid
-            mid = right // 2
+            mid = left + (right - left) // 2
 
             ctx.log_route(r, "info", "Probing lower execution plans", [])
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -42,6 +42,13 @@ logger = logging.getLogger(__name__)
 
 MAX_POOL_LIQUIDITY_TRADE = Decimal("0.05")
 
+
+"""
+Prevent routes from being evaluated excessively when binary search fails.
+"""
+MAX_EVAL_PROBES = 2**6
+
+
 """
 The amount of the summed gas limit that will be consumed if messages
 are batched together.
@@ -1198,7 +1205,11 @@ async def quantities_for_route_profit(
     # Plans sorted by profit, for purposes of returning the best plan
     plans_by_profit: list[int] = []
 
-    while mid > 0 and mid <= starting_amount:
+    attempts: int = 0
+
+    while mid > 0 and mid <= starting_amount and attempts < MAX_EVAL_PROBES:
+        attempts += 1
+
         quantities: list[int] = await quantities_for_starting_amount(mid, route)
         plans[mid] = quantities
 

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -27,6 +27,7 @@ from src.util import (
     try_multiple_clients_fatal,
     try_multiple_clients,
     DenomRouteQuery,
+    fmt_denom_route_leg,
 )
 from src.scheduler import Ctx
 from cosmos.base.v1beta1 import coin_pb2
@@ -961,6 +962,13 @@ async def transfer(
             dest_chain=leg.backend.chain_id,
             dest_denom=denom_infos_on_dest.denom,
         )
+    )
+
+    ctx.log_route(
+        route,
+        "info",
+        "Got potential transfer route: %s",
+        [fmt_denom_route_leg(leg) for leg in ibc_route],
     )
 
     if not ibc_route or len(ibc_route) == 0:

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -616,7 +616,7 @@ async def rebalance_portfolio(
                     [denom],
                 )
 
-                continue
+                return
 
             # Check that the execution plan results in a liquidatable quantity
             if execution_plan[-1] < ctx.cli_args["rebalance_threshold"]:
@@ -627,7 +627,7 @@ async def rebalance_portfolio(
                     [denom],
                 )
 
-                continue
+                return
 
             ctx.log_route(
                 route_ent, "info", "Executing rebalancing plan for %s", [denom]
@@ -639,8 +639,6 @@ async def rebalance_portfolio(
 
             try:
                 await exec_arb(route_ent, 0, execution_plan, route, ctx)
-
-                break
             except Exception:
                 ctx.log_route(
                     route_ent,

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -43,6 +43,9 @@ logger = logging.getLogger(__name__)
 MAX_POOL_LIQUIDITY_TRADE = Decimal("0.05")
 
 
+DENOM_QUANTITY_ABORT_ARB = 500
+
+
 """
 Prevent routes from being evaluated excessively when binary search fails.
 """

--- a/src/strategies/util.py
+++ b/src/strategies/util.py
@@ -598,6 +598,8 @@ async def rebalance_portfolio(
                 auctions,
                 ctx,
             ):
+                route_ent.logs_enabled = ctx.cli_args["log_rebalancing"]
+
                 # For logging
                 _, execution_plan = await quantities_for_route_profit(
                     balance, route, route_ent, ctx, seek_profit=False

--- a/src/util.py
+++ b/src/util.py
@@ -21,9 +21,6 @@ from cosmwasm.wasm.v1 import query_pb2, query_pb2_grpc
 DENOM_RESOLVER_TIMEOUT_SEC = 5
 
 
-DENOM_QUANTITY_ABORT_ARB = 500
-
-
 # Dictates the maximum number of concurrent calls to the skip
 # API in searching
 DISCOVERY_CONCURRENCY_FACTOR = 15

--- a/src/util.py
+++ b/src/util.py
@@ -309,6 +309,12 @@ def load_denom_route_leg(obj: dict[str, Any]) -> DenomRouteLeg:
     )
 
 
+def fmt_denom_route_leg(leg: DenomRouteLeg) -> str:
+    return (
+        f"{src_denom} ({src_chain}) -> {dest_denom} ({dest_chain}) via {channel}/{port}"
+    )
+
+
 @dataclass
 class DenomChainInfo:
     """

--- a/src/util.py
+++ b/src/util.py
@@ -310,9 +310,7 @@ def load_denom_route_leg(obj: dict[str, Any]) -> DenomRouteLeg:
 
 
 def fmt_denom_route_leg(leg: DenomRouteLeg) -> str:
-    return (
-        f"{src_denom} ({src_chain}) -> {dest_denom} ({dest_chain}) via {channel}/{port}"
-    )
+    return f"{leg.src_denom} ({leg.src_chain}) -> {leg.dest_denom} ({leg.dest_chain}) via {leg.channel}/{leg.port}"
 
 
 @dataclass

--- a/src/util.py
+++ b/src/util.py
@@ -256,6 +256,21 @@ class ChainInfo:
 
 
 @dataclass
+class DenomRouteQuery:
+    """
+    Information identifying a request for a denom route.
+    """
+
+    src_chain: str
+    src_denom: str
+    dest_chain: str
+    dest_denom: str
+
+    def __hash__(self) -> int:
+        return hash((self.src_chain, self.src_denom, self.dest_chain, self.dest_denom))
+
+
+@dataclass
 class DenomRouteLeg:
     """
     Represents an IBC transfer as a leg of a greater IBC transfer
@@ -290,205 +305,8 @@ class DenomChainInfo:
     """
 
     denom: str
-    chain_id: Optional[str]
-
-
-async def denom_info(
-    src_chain: str,
-    src_denom: str,
-    session: aiohttp.ClientSession,
-    denom_map: Optional[dict[str, list[dict[str, str]]]] = None,
-) -> list[list[DenomChainInfo]]:
-    """
-    Gets a denom's denom and channel on/to other chains.
-    """
-
-    if denom_map:
-        return [
-            [
-                DenomChainInfo(
-                    denom_info["denom"],
-                    denom_info["chain_id"],
-                )
-            ]
-            for denom_info in denom_map.get(src_denom, [])
-        ]
-
-    head = {"accept": "application/json", "content-type": "application/json"}
-
-    async with session.post(
-        "https://api.skip.money/v1/fungible/assets_from_source",
-        headers=head,
-        json={
-            "allow_multi_tx": False,
-            "include_cw20_assets": True,
-            "source_asset_denom": src_denom,
-            "source_asset_chain_id": src_chain,
-            "client_id": "timewave-arb-bot",
-        },
-    ) as resp:
-        if resp.status != 200:
-            return []
-
-        dests = (await resp.json())["dest_assets"]
-
-        def chain_info(chain_id: str, info: dict[str, Any]) -> DenomChainInfo:
-            info = info["assets"][0]
-
-            return DenomChainInfo(denom=info["denom"], chain_id=chain_id)
-
-        return [[chain_info(chain_id, info) for chain_id, info in dests.items()]]
-
-
-async def denom_info_on_chain(
-    src_chain: str,
-    src_denom: str,
-    dest_chain: str,
-    session: aiohttp.ClientSession,
-    denom_map: Optional[dict[str, list[dict[str, str]]]] = None,
-) -> Optional[list[DenomChainInfo]]:
-    """
-    Gets a neutron denom's denom and channel on/to another chain.
-    """
-
-    if denom_map:
-        return [
-            DenomChainInfo(
-                denom_info["denom"],
-                denom_info["chain_id"],
-            )
-            for denom_info in denom_map.get(src_denom, [])
-            if denom_info["chain_id"] == dest_chain
-        ][:1]
-
-    head = {"accept": "application/json", "content-type": "application/json"}
-
-    async with session.post(
-        "https://api.skip.money/v1/fungible/assets_from_source",
-        headers=head,
-        json={
-            "allow_multi_tx": False,
-            "include_cw20_assets": True,
-            "source_asset_denom": src_denom,
-            "source_asset_chain_id": src_chain,
-            "client_id": "timewave-arb-bot",
-        },
-    ) as resp:
-        if resp.status != 200:
-            return None
-
-        dests = (await resp.json())["dest_assets"]
-
-        if dest_chain in dests:
-            info = dests[dest_chain]["assets"][0]
-
-            return [DenomChainInfo(denom=info["denom"], chain_id=dest_chain)]
-
-        return None
-
-
-async def denom_route(
-    src_chain: str,
-    src_denom: str,
-    dest_chain: str,
-    dest_denom: str,
-    session: aiohttp.ClientSession,
-    denom_map: Optional[dict[str, list[dict[str, str]]]] = None,
-) -> Optional[list[DenomRouteLeg]]:
-    """
-    Gets a neutron denom's denom and channel on/to another chain.
-    """
-
-    head = {"accept": "application/json", "content-type": "application/json"}
-
-    async with session.post(
-        "https://api.skip.money/v2/fungible/route",
-        headers=head,
-        json={
-            "amount_in": "1",
-            "source_asset_denom": src_denom,
-            "source_asset_chain_id": src_chain,
-            "dest_asset_denom": dest_denom,
-            "dest_asset_chain_id": dest_chain,
-            "allow_multi_tx": True,
-            "allow_unsafe": False,
-            "bridges": ["IBC"],
-        },
-    ) as resp:
-        if resp.status != 200:
-            return None
-
-        ops = (await resp.json())["operations"]
-
-        # The transfer includes a swap or some other operation
-        # we can't handle
-        if any(("transfer" not in op for op in ops)):
-            return None
-
-        transfer_info = ops[0]["transfer"]
-
-        from_chain_info = await chain_info(
-            transfer_info["from_chain_id"], session, denom_map
-        )
-        to_chain_info = await chain_info(
-            transfer_info["to_chain_id"], session, denom_map
-        )
-
-        if not from_chain_info or not to_chain_info:
-            return None
-
-        return [
-            DenomRouteLeg(
-                src_chain=src_chain,
-                dest_chain=dest_chain,
-                src_denom=src_denom,
-                dest_denom=dest_denom,
-                from_chain=from_chain_info,
-                to_chain=to_chain_info,
-                denom_in=transfer_info["denom_in"],
-                denom_out=transfer_info["denom_out"],
-                port=transfer_info["port"],
-                channel=transfer_info["channel"],
-            )
-            for op in ops
-        ]
-
-
-async def chain_info(
-    chain_id: str,
-    session: aiohttp.ClientSession,
-    denom_map: Optional[dict[str, list[dict[str, str]]]] = None,
-) -> Optional[ChainInfo]:
-    """
-    Gets basic information about a cosmos chain.
-    """
-
-    head = {"accept": "application/json", "content-type": "application/json"}
-
-    async with session.get(
-        f"https://api.skip.money/v2/info/chains?chain_ids={chain_id}",
-        headers=head,
-    ) as resp:
-        if resp.status != 200:
-            return None
-
-        chains = (await resp.json())["chains"]
-
-        if len(chains) == 0:
-            return None
-
-        chain = chains[0]
-
-        return ChainInfo(
-            chain_name=chain["chain_name"],
-            chain_id=chain["chain_id"],
-            pfm_enabled=chain["pfm_enabled"],
-            supports_memo=chain["supports_memo"],
-            bech32_prefix=chain["bech32_prefix"],
-            fee_asset=chain["fee_assets"][0]["denom"],
-            chain_type=chain["chain_type"],
-            pretty_name=chain["pretty_name"],
-        )
+    src_chain_id: str
+    dest_chain_id: str
 
 
 @dataclass

--- a/src/util.py
+++ b/src/util.py
@@ -21,6 +21,9 @@ from cosmwasm.wasm.v1 import query_pb2, query_pb2_grpc
 DENOM_RESOLVER_TIMEOUT_SEC = 5
 
 
+DENOM_QUANTITY_ABORT_ARB = 500
+
+
 # Dictates the maximum number of concurrent calls to the skip
 # API in searching
 DISCOVERY_CONCURRENCY_FACTOR = 15

--- a/src/util.py
+++ b/src/util.py
@@ -28,7 +28,7 @@ MAX_SKIP_CONCURRENT_CALLS = 5
 
 # Dictates the maximum number of concurrent calls to the skip
 # API in searching
-DISCOVERY_CONCURRENCY_FACTOR = 20
+DISCOVERY_CONCURRENCY_FACTOR = 15
 
 
 # Dictates the maximum number of concurrent calls to pool providers

--- a/src/util.py
+++ b/src/util.py
@@ -36,11 +36,6 @@ DISCOVERY_CONCURRENCY_FACTOR = 20
 EVALUATION_CONCURRENCY_FACTOR = 10
 
 
-# The quantity of a denom below which
-# it is no longer worthwhile checking for profit
-DENOM_QUANTITY_ABORT_ARB = 500
-
-
 NEUTRON_NETWORK_CONFIG = NetworkConfig(
     chain_id="neutron-1",
     url="grpc+http://grpc-kralum.neutron-1.neutron.org:80",
@@ -255,6 +250,19 @@ class ChainInfo:
     pretty_name: str
 
 
+def load_chain_info(obj: dict[str, Any]) -> ChainInfo:
+    return ChainInfo(
+        chain_name=obj["chain_name"],
+        chain_id=obj["chain_id"],
+        pfm_enabled=obj["pfm_enabled"],
+        supports_memo=obj["supports_memo"],
+        bech32_prefix=obj["bech32_prefix"],
+        fee_asset=obj["fee_asset"],
+        chain_type=obj["chain_type"],
+        pretty_name=obj["pretty_name"],
+    )
+
+
 @dataclass
 class DenomRouteQuery:
     """
@@ -289,11 +297,21 @@ class DenomRouteLeg:
     from_chain: ChainInfo
     to_chain: ChainInfo
 
-    denom_in: str
-    denom_out: str
-
     port: str
     channel: str
+
+
+def load_denom_route_leg(obj: dict[str, Any]) -> DenomRouteLeg:
+    return DenomRouteLeg(
+        src_chain=obj["src_chain"],
+        dest_chain=obj["dest_chain"],
+        src_denom=obj["src_denom"],
+        dest_denom=obj["dest_denom"],
+        from_chain=load_chain_info(obj["from_chain"]),
+        to_chain=load_chain_info(obj["to_chain"]),
+        port=obj["port"],
+        channel=obj["channel"],
+    )
 
 
 @dataclass
@@ -307,6 +325,14 @@ class DenomChainInfo:
     denom: str
     src_chain_id: str
     dest_chain_id: str
+
+
+def load_denom_chain_info(obj: dict[str, Any]) -> DenomChainInfo:
+    return DenomChainInfo(
+        denom=obj["denom"],
+        src_chain_id=obj["src_chain_id"],
+        dest_chain_id=obj["dest_chain_id"],
+    )
 
 
 @dataclass

--- a/src/util.py
+++ b/src/util.py
@@ -21,11 +21,6 @@ from cosmwasm.wasm.v1 import query_pb2, query_pb2_grpc
 DENOM_RESOLVER_TIMEOUT_SEC = 5
 
 
-# The maximum number of concurrent connections
-# that can be open to
-MAX_SKIP_CONCURRENT_CALLS = 5
-
-
 # Dictates the maximum number of concurrent calls to the skip
 # API in searching
 DISCOVERY_CONCURRENCY_FACTOR = 15

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -84,7 +84,7 @@ async def test_auction_provider() -> None:
                         * price
                     )
                     assert liq_estimate - liquidity < 5
-                    assert liquidity - liq_estimate < 100
+                    assert liquidity - liq_estimate < 1000
 
 
 @pytest.mark.asyncio

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -84,7 +84,6 @@ async def test_auction_provider() -> None:
                         * price
                     )
                     assert liq_estimate - liquidity < 5
-                    assert liquidity - liq_estimate < 1000
 
 
 @pytest.mark.asyncio

--- a/tests/test_naive_strategy.py
+++ b/tests/test_naive_strategy.py
@@ -3,11 +3,7 @@ Tests the naive strategy.
 """
 
 import typing
-from typing import Any
 from dataclasses import dataclass
-import json
-from src.util import custom_neutron_network_config
-from src.scheduler import Ctx
 from src.strategies.util import fmt_route_leg, IBC_TRANSFER_GAS
 from src.strategies.naive import State, route_gas
 from src.contracts.pool.osmosis import OsmosisPoolDirectory
@@ -15,9 +11,7 @@ from src.contracts.route import Leg
 from src.contracts.pool.astroport import NeutronAstroportPoolDirectory
 from src.contracts.auction import AuctionDirectory
 from src.util import DISCOVERY_CONCURRENCY_FACTOR
-from tests.util import deployments
-from cosmpy.aerial.client import LedgerClient
-from cosmpy.aerial.wallet import LocalWallet
+from tests.util import deployments, ctx
 import pytest
 import aiohttp
 import grpc
@@ -91,44 +85,9 @@ async def test_fmt_route_leg() -> None:
 
 @pytest.mark.asyncio
 async def test_state_poll() -> None:
-    net_config, deployments = (None, None)
-
-    with open("net_conf.json", "r", encoding="utf-8") as nf:
-        net_config = json.load(nf)
-
-    with open("contracts/deployments.json", "r", encoding="utf-8") as f:
-        deployments = json.load(f)
-
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(force_close=True, limit_per_host=1),
-        timeout=aiohttp.ClientTimeout(total=30),
-    ) as session:
-        ctx: Ctx[Any] = Ctx(
-            {
-                chain_id: [
-                    LedgerClient(
-                        custom_neutron_network_config(endpoint, chain_id=chain_id)
-                    )
-                    for endpoint in endpoints["grpc"]
-                ]
-                for chain_id, endpoints in net_config.items()
-            },
-            net_config,
-            LocalWallet.from_mnemonic(
-                "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry",
-                prefix="neutron",
-            ),
-            {"base_denom": "untrn"},
-            None,
-            False,
-            session,
-            [],
-            deployments,
-            None,
-        )
-
+    async with ctx() as test_ctx:
         s = State(None)
-        s.poll(ctx, {}, {})
+        s.poll(test_ctx, {}, {})
 
         assert s.balance
         assert s.balance > 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,42 +2,23 @@
 Tests that the scheduler works as expected.
 """
 
-from dataclasses import dataclass
-import json
-from typing import List, cast, Any
-from cosmpy.aerial.client import LedgerClient, NetworkConfig
-from cosmpy.aerial.wallet import LocalWallet
 from src.scheduler import Scheduler, Ctx
-from src.util import (
-    NEUTRON_NETWORK_CONFIG,
-    DISCOVERY_CONCURRENCY_FACTOR,
-    custom_neutron_network_config,
-)
+from src.util import DISCOVERY_CONCURRENCY_FACTOR
 from src.contracts.pool.osmosis import OsmosisPoolDirectory
 from src.contracts.pool.astroport import NeutronAstroportPoolDirectory
 from src.contracts.pool.provider import PoolProvider
 from src.contracts.auction import AuctionProvider
-from tests.util import deployments
+from tests.util import deployments, ctx, State
 import aiohttp
 import pytest
 import grpc
 
 pytest_plugins = ("pytest_asyncio",)
 
-# Note: this account has no funds and is not used for anything
-TEST_WALLET_MNEMONIC = (
-    "update armed valve web gate shiver birth exclude curtain cotton juice property"
-)
-
-
-@dataclass
-class State:
-    balance: int
-
 
 async def strategy(
     strat_ctx: Ctx[State],
-    _pools: dict[str, dict[str, List[PoolProvider]]],
+    _pools: dict[str, dict[str, list[PoolProvider]]],
     _auctions: dict[str, dict[str, AuctionProvider]],
 ) -> Ctx[State]:
     """
@@ -47,86 +28,14 @@ async def strategy(
     return strat_ctx
 
 
-def ctx(session: aiohttp.ClientSession) -> Ctx[State]:
-    """
-    Gets a default context for test schedulers.
-    """
-
-    endpoints: dict[str, dict[str, list[str]]] = {
-        "neutron-1": {
-            "http": ["https://neutron-rest.publicnode.com"],
-            "grpc": ["grpc+https://neutron-grpc.publicnode.com:443"],
-        },
-        "osmosis-1": {
-            "http": ["https://lcd.osmosis.zone"],
-            "grpc": ["grpc+https://osmosis-grpc.publicnode.com:443"],
-        },
-    }
-
-    with open("contracts/deployments.json", encoding="utf-8") as f:
-        return Ctx(
-            {
-                "neutron-1": [
-                    LedgerClient(NEUTRON_NETWORK_CONFIG),
-                    *[
-                        LedgerClient(custom_neutron_network_config(endpoint))
-                        for endpoint in endpoints["neutron-1"]["grpc"]
-                    ],
-                ],
-                "osmosis-1": [
-                    *[
-                        LedgerClient(
-                            NetworkConfig(
-                                chain_id="osmosis-1",
-                                url=endpoint,
-                                fee_minimum_gas_price=0.0053,
-                                fee_denomination="uosmo",
-                                staking_denomination="uosmo",
-                            )
-                        )
-                        for endpoint in endpoints["osmosis-1"]["grpc"]
-                    ],
-                ],
-            },
-            endpoints,
-            LocalWallet.from_mnemonic(TEST_WALLET_MNEMONIC, prefix="neutron"),
-            {
-                "pool_file": None,
-                "poll_interval": 120,
-                "hops": 3,
-                "pools": 100,
-                "require_leg_types": set(),
-                "base_denom": "",
-                "profit_margin": 100,
-                "wallet_mnemonic": "",
-                "cmd": "",
-                "net_config": "",
-                "log_file": "",
-                "history_file": "",
-                "skip_api_key": None,
-            },
-            None,
-            False,
-            session,
-            [],
-            cast(dict[str, Any], json.load(f)),
-            None,
-        ).with_state(State(1000))
-
-
 @pytest.mark.asyncio
 async def test_init() -> None:
     """
     Test that a scheduler can be instantiated.
     """
 
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(
-            force_close=True, limit_per_host=DISCOVERY_CONCURRENCY_FACTOR
-        ),
-        timeout=aiohttp.ClientTimeout(total=30),
-    ) as session:
-        sched = Scheduler(ctx(session), strategy)
+    async with ctx() as test_ctx:
+        sched = Scheduler(test_ctx, strategy)
         assert sched is not None
 
 
@@ -145,16 +54,17 @@ async def test_register_provider() -> None:
         osmosis = OsmosisPoolDirectory(deployments(), session)
         pool = list(list((await osmosis.pools()).values())[0].values())[0]
 
-        sched = Scheduler(ctx(session), strategy)
+        async with ctx() as test_ctx:
+            sched = Scheduler(test_ctx, strategy)
 
-        directory = OsmosisPoolDirectory(deployments(), session)
-        pools = await directory.pools()
+            directory = OsmosisPoolDirectory(deployments(), session)
+            pools = await directory.pools()
 
-        for base in pools.values():
-            for pool in base.values():
-                sched.register_provider(pool)
+            for base in pools.values():
+                for pool in base.values():
+                    sched.register_provider(pool)
 
-        assert len(sched.providers) > 0
+            assert len(sched.providers) > 0
 
 
 @pytest.mark.asyncio
@@ -184,7 +94,7 @@ async def test_poll() -> None:
 
         async def simple_strategy(
             strat_ctx: Ctx[State],
-            pools: dict[str, dict[str, List[PoolProvider]]],
+            pools: dict[str, dict[str, list[PoolProvider]]],
             auctions: dict[str, dict[str, AuctionProvider]],
         ) -> Ctx[State]:
             assert len(pools) > 0
@@ -192,18 +102,19 @@ async def test_poll() -> None:
 
             return strat_ctx
 
-        sched = Scheduler(ctx(session), simple_strategy)
+        async with ctx() as test_ctx:
+            sched = Scheduler(test_ctx, simple_strategy)
 
-        await sched.register_auctions()
-        osmos_pools = await osmosis.pools()
-        astro_pools = await astroport.pools()
+            await sched.register_auctions()
+            osmos_pools = await osmosis.pools()
+            astro_pools = await astroport.pools()
 
-        for base in osmos_pools.values():
-            for pool in base.values():
-                sched.register_provider(pool)
+            for base in osmos_pools.values():
+                for pool in base.values():
+                    sched.register_provider(pool)
 
-        for astro_base in astro_pools.values():
-            for astro_pool in astro_base.values():
-                sched.register_provider(astro_pool)
+            for astro_base in astro_pools.values():
+                for astro_pool in astro_base.values():
+                    sched.register_provider(astro_pool)
 
-        await sched.poll()
+            await sched.poll()

--- a/tests/test_strategy_util.py
+++ b/tests/test_strategy_util.py
@@ -3,7 +3,7 @@
 from typing import Any
 from src.contracts.route import Leg
 from src.strategies.util import collapse_route, build_atomic_arb
-from tests.test_scheduler import TEST_WALLET_MNEMONIC
+from tests.util import TEST_WALLET_MNEMONIC
 from cosmpy.aerial.wallet import LocalWallet
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,9 +2,9 @@
 Tests that the skip util methods work as expected.
 """
 
-from src.util import denom_info, denom_info_on_chain, denom_route
+from src.util import DenomRouteQuery
+from tests.util import ctx
 import pytest
-import aiohttp
 
 pytest_plugins = ("pytest_asyncio",)
 
@@ -15,19 +15,15 @@ async def test_denom_info() -> None:
     Tests that skip can fetch the destination chains for untrn.
     """
 
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(force_close=True, limit_per_host=1),
-        timeout=aiohttp.ClientTimeout(total=30),
-    ) as session:
-        info = await denom_info("neutron-1", "untrn", session)
+    async with ctx() as test_ctx:
+        info = await test_ctx.query_denom_info("neutron-1", "untrn")
 
         assert info
         assert len(info) > 0
-        assert len(info[0]) > 0
 
-        assert info[0][0].chain_id == "archway-1"
+        assert info[0].dest_chain_id == "archway-1"
         assert (
-            info[0][0].denom
+            info[0].denom
             == "ibc/9E3CDA65E02637E219B43802452D6B37D782F466CF76ECB9F47A2E00C07C4769"
         )
 
@@ -38,33 +34,29 @@ async def test_denom_info_on_chain() -> None:
     Tests that skip can fetch the osmosis destination chain info for untrn.
     """
 
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(force_close=True, limit_per_host=1),
-        timeout=aiohttp.ClientTimeout(total=30),
-    ) as session:
-        info = await denom_info_on_chain("neutron-1", "untrn", "osmosis-1", session)
+    async with ctx() as test_ctx:
+        info = await test_ctx.query_denom_info_on_chain(
+            "neutron-1", "untrn", "osmosis-1"
+        )
 
         assert info
-        assert len(info) > 0
 
         assert (
-            info[0].denom
+            info.denom
             == "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682"
         )
-        assert info[0].chain_id == "osmosis-1"
+        assert info.dest_chain_id == "osmosis-1"
 
-        info = await denom_info_on_chain(
+        info = await test_ctx.query_denom_info_on_chain(
             "neutron-1",
             "ibc/376222D6D9DAE23092E29740E56B758580935A6D77C24C2ABD57A6A78A1F3955",
             "osmosis-1",
-            session,
         )
 
         assert info
-        assert len(info) > 0
 
-        assert info[0].denom == "uosmo"
-        assert info[0].chain_id == "osmosis-1"
+        assert info.denom == "uosmo"
+        assert info.dest_chain_id == "osmosis-1"
 
 
 @pytest.mark.asyncio
@@ -73,16 +65,15 @@ async def test_denom_route() -> None:
     Tests that skip can fetch the route for USDC from neutron to osmosis.
     """
 
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(force_close=True, limit_per_host=1),
-        timeout=aiohttp.ClientTimeout(total=30),
-    ) as session:
-        info = await denom_route(
-            "neutron-1",
-            "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81",
-            "osmosis-1",
-            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            session,
+    async with ctx() as test_ctx:
+
+        info = await test_ctx.query_denom_route(
+            DenomRouteQuery(
+                src_chain="neutron-1",
+                src_denom="ibc/376222D6D9DAE23092E29740E56B758580935A6D77C24C2ABD57A6A78A1F3955",
+                dest_chain="osmosis-1",
+                dest_denom="uosmo",
+            )
         )
 
         assert info
@@ -90,12 +81,13 @@ async def test_denom_route() -> None:
 
         assert info
 
-        info = await denom_route(
-            "neutron-1",
-            "ibc/376222D6D9DAE23092E29740E56B758580935A6D77C24C2ABD57A6A78A1F3955",
-            "osmosis-1",
-            "uosmo",
-            session,
+        info = await test_ctx.query_denom_route(
+            DenomRouteQuery(
+                src_chain="neutron-1",
+                src_denom="ibc/376222D6D9DAE23092E29740E56B758580935A6D77C24C2ABD57A6A78A1F3955",
+                dest_chain="osmosis-1",
+                dest_denom="uosmo",
+            )
         )
 
         assert info

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,4 @@
-from asyncio import Lock
+from asyncio import Semaphore
 from typing import Any, cast, AsyncIterator
 import json
 import aiohttp
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from cosmpy.aerial.client import LedgerClient, NetworkConfig
 from cosmpy.aerial.wallet import LocalWallet
-from src.scheduler import Ctx
+from src.scheduler import Ctx, MAX_SKIP_CONCURRENT_CALLS
 from src.util import (
     DISCOVERY_CONCURRENCY_FACTOR,
     NEUTRON_NETWORK_CONFIG,
@@ -109,5 +109,5 @@ async def ctx() -> AsyncIterator[Ctx[Any]]:
                 denom_map={},
                 denom_routes={},
                 chain_info={},
-                http_session_lock=Lock(),
+                http_session_lock=Semaphore(MAX_SKIP_CONCURRENT_CALLS),
             ).with_state(State(1000))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+from asyncio import Lock
 from typing import Any, cast, AsyncIterator
 import json
 import aiohttp
@@ -108,4 +109,5 @@ async def ctx() -> AsyncIterator[Ctx[Any]]:
                 denom_map={},
                 denom_routes={},
                 chain_info={},
+                http_session_lock=Lock(),
             ).with_state(State(1000))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+from sqlite3 import connect
 from asyncio import Semaphore
 from typing import Any, cast, AsyncIterator
 import json
@@ -98,12 +99,13 @@ async def ctx() -> AsyncIterator[Ctx[Any]]:
                     "cmd": "",
                     "net_config": "",
                     "log_file": "",
-                    "history_file": "",
+                    "history_db": "",
                     "skip_api_key": None,
                 },
                 state=None,
                 terminated=False,
                 http_session=session,
+                db_connection=connect("test_db.db"),
                 order_history=[],
                 deployments=cast(dict[str, Any], json.load(f)),
                 denom_map={},

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,27 @@
-from typing import Any, cast
+from typing import Any, cast, AsyncIterator
 import json
+import aiohttp
+from dataclasses import dataclass
+from contextlib import asynccontextmanager
+from cosmpy.aerial.client import LedgerClient, NetworkConfig
+from cosmpy.aerial.wallet import LocalWallet
+from src.scheduler import Ctx
+from src.util import (
+    DISCOVERY_CONCURRENCY_FACTOR,
+    NEUTRON_NETWORK_CONFIG,
+    custom_neutron_network_config,
+)
+
+
+@dataclass
+class State:
+    balance: int
+
+
+# Note: this account has no funds and is not used for anything
+TEST_WALLET_MNEMONIC = (
+    "update armed valve web gate shiver birth exclude curtain cotton juice property"
+)
 
 
 def deployments() -> dict[str, Any]:
@@ -9,3 +31,81 @@ def deployments() -> dict[str, Any]:
     """
     with open("contracts/deployments.json", encoding="utf-8") as f:
         return cast(dict[str, Any], json.load(f))
+
+
+@asynccontextmanager
+async def ctx() -> AsyncIterator[Ctx[Any]]:
+    """
+    Gets a default context for test schedulers.
+    """
+
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(
+            force_close=True, limit_per_host=DISCOVERY_CONCURRENCY_FACTOR
+        ),
+        timeout=aiohttp.ClientTimeout(total=30),
+    ) as session:
+        endpoints: dict[str, dict[str, list[str]]] = {
+            "neutron-1": {
+                "http": ["https://neutron-rest.publicnode.com"],
+                "grpc": ["grpc+https://neutron-grpc.publicnode.com:443"],
+            },
+            "osmosis-1": {
+                "http": ["https://lcd.osmosis.zone"],
+                "grpc": ["grpc+https://osmosis-grpc.publicnode.com:443"],
+            },
+        }
+
+        with open("contracts/deployments.json", encoding="utf-8") as f:
+            yield Ctx(
+                clients={
+                    "neutron-1": [
+                        LedgerClient(NEUTRON_NETWORK_CONFIG),
+                        *[
+                            LedgerClient(custom_neutron_network_config(endpoint))
+                            for endpoint in endpoints["neutron-1"]["grpc"]
+                        ],
+                    ],
+                    "osmosis-1": [
+                        *[
+                            LedgerClient(
+                                NetworkConfig(
+                                    chain_id="osmosis-1",
+                                    url=endpoint,
+                                    fee_minimum_gas_price=0.0053,
+                                    fee_denomination="uosmo",
+                                    staking_denomination="uosmo",
+                                )
+                            )
+                            for endpoint in endpoints["osmosis-1"]["grpc"]
+                        ],
+                    ],
+                },
+                endpoints=endpoints,
+                wallet=LocalWallet.from_mnemonic(
+                    TEST_WALLET_MNEMONIC, prefix="neutron"
+                ),
+                cli_args={
+                    "pool_file": None,
+                    "poll_interval": 120,
+                    "hops": 3,
+                    "pools": 100,
+                    "require_leg_types": set(),
+                    "base_denom": "",
+                    "profit_margin": 100,
+                    "wallet_mnemonic": "",
+                    "cmd": "",
+                    "net_config": "",
+                    "log_file": "",
+                    "history_file": "",
+                    "skip_api_key": None,
+                },
+                state=None,
+                terminated=False,
+                http_session=session,
+                order_history=[],
+                deployments=cast(dict[str, Any], json.load(f)),
+                denom_map={},
+                denom_routes={},
+                chain_info={},
+            ).with_state(State(1000))


### PR DESCRIPTION
This PR finalizes Osmosis local-ic integration test implementation. This was achieved by centralizing Skip queries in the Context, allowing for injection of IBC paths and denom info. Furthermore, several bug fixes were made in the process, allowing for these tests to pass, including the addition of route reevaluation (updating quantities in the execution plan in accordance with slight slippage at any step of the plan that would cause it to be invalidated), and a binary search based execution planner (allowing for tighter execution plan-wallet balance differences, and maximizing profit per trade). Furthermore, several other quality of life improvements were made, including leg balance prefixing in route logs, which assists in debugging.

An example of this is as follows:

`2024-10-04 15:18:21 INFO     balance[neutron-1](untrn): 15503863 balance[neutron-1](factory/neut): 5681 r2- Route has possible execution plan: [5681]`